### PR TITLE
Add a basic unit test

### DIFF
--- a/src/leiningen/new/mies_node.clj
+++ b/src/leiningen/new/mies_node.clj
@@ -9,5 +9,6 @@
     (->files data
       ["project.clj" (render "project.clj" data)]
       ["src/{{sanitized}}/core.cljs" (render "core.cljs" data)]
+      ["test/{{sanitized}}/test/core.cljs" (render "test.cljs" data)]
       ["run.js" (render "run.js" data)]
       [".gitignore" (render "gitignore" data)])))

--- a/src/leiningen/new/mies_node/project.clj
+++ b/src/leiningen/new/mies_node/project.clj
@@ -5,7 +5,10 @@
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojure/clojurescript "0.0-2311"]]
 
-  :plugins [[lein-cljsbuild "1.0.4-SNAPSHOT"]]
+  :plugins [[lein-cljsbuild "1.0.4-SNAPSHOT"]
+            [com.cemerick/clojurescript.test "0.3.1"]]
+
+  :hooks [leiningen.cljsbuild]
 
   :source-paths ["src"]
 
@@ -17,4 +20,14 @@
                 :output-dir "out"
                 :target :nodejs
                 :optimizations :none
-                :source-map true}}]})
+                :source-map true}}
+             {:id "test"
+              :source-paths ["src" "test"]
+              :compiler {
+                :output-to "out/{{sanitized}}-testable.js"
+                :output-dir "out/test"
+                :target :nodejs
+                :optimizations :simple
+                :hashbang false}}]
+              :test-commands {"unit-tests" ["node" :node-runner
+                                            "out/{{sanitized}}-testable.js"]}})

--- a/src/leiningen/new/mies_node/test.cljs
+++ b/src/leiningen/new/mies_node/test.cljs
@@ -1,0 +1,9 @@
+(ns {{name}}.test.core
+  (:require-macros [cemerick.cljs.test
+                    :refer (is deftest with-test run-tests testing test-var)])
+  (:require [cemerick.cljs.test :as t]))
+
+(deftest test-should-fail
+  (testing "This should fail"
+    (is (= true (not true)))))
+


### PR DESCRIPTION
I found setting up the unit tests on node a bit painful, given that there's pretty limited documentation on running them in a node context, as well as the addition of the `:hashbang` compiler option.  This addition would certainly save people the trouble of getting these settings right.
