### PR TITLE
Bump clojurescript dep for node 0.12 support.

### DIFF
--- a/src/leiningen/new/mies_node/project.clj
+++ b/src/leiningen/new/mies_node/project.clj
@@ -3,7 +3,7 @@
   :url "http://example.com/FIXME"
 
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.clojure/clojurescript "0.0-2755"]]
+                 [org.clojure/clojurescript "0.0-3126"]]
 
   :node-dependencies [[source-map-support "0.2.8"]]
 


### PR DESCRIPTION
Needed to bump clojurescript to the latest release in order for things to work
with node v0.12.0.